### PR TITLE
Plone 6 and pas.plugin.oidc compatibility

### DIFF
--- a/iw/rejectanonymous/__init__.py
+++ b/iw/rejectanonymous/__init__.py
@@ -33,7 +33,7 @@ class IPrivateSite(Interface):
 
 
 valid_ids = frozenset((
-    'login', 'login_form', 'require_login',
+    'login', 'login_form', 'require_login', 'callback',
     'mail_password_form', 'mail_password', 'contact-info', 'pwreset_form', 'pwreset_finish',
     'login.js', 'config.js', 'plonejsi18n', 'less-variables.js',
     'favicon.ico', 'logo.jpg', 'logo.png', 'spinner.gif',

--- a/iw/rejectanonymous/configure.zcml
+++ b/iw/rejectanonymous/configure.zcml
@@ -10,13 +10,6 @@
            zope.traversing.interfaces.IBeforeTraverseEvent"
   />
 
-  <browser:viewlet
-    name="plone.personal_bar"
-    for="iw.rejectanonymous.IPrivateSite"
-    manager="plone.app.layout.viewlets.interfaces.IPortalHeader"
-    class="plone.app.layout.viewlets.common.PersonalBarViewlet"
-    permission="cmf.SetOwnProperties"
-  />
 
   <browser:viewlet
     name="plone.searchbox"


### PR DESCRIPTION
This change adds 'callback' as a valid ID, ensuring compatibility with pas.plugin.oidc.

Otherwise, a site configured with both iw.rejectanonymous and pas.plugin.oidc leads to a login redirect cycle.