### PR TITLE
Support the requests done with ftw.upgrade script.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes log
 1.2.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support the requests done with ftw.upgrade script.
+  [ale-rt]
 
 
 1.2.7 (2023-05-08)

--- a/iw/rejectanonymous/__init__.py
+++ b/iw/rejectanonymous/__init__.py
@@ -45,7 +45,7 @@ if HAS_RESTAPI:
     valid_ids = valid_ids.union(('reset-password', '@login', '@login-renew', '@logout'))
 
 valid_subparts = frozenset((
-    'portal_css', 'portal_javascripts', 'passwordreset', 'portal_kss'
+    'portal_css', 'portal_javascripts', 'passwordreset', 'portal_kss', 'upgrades-api',
 ))
 
 valid_subpart_prefixes = frozenset(('++resource++', '++theme++', '++plone++',


### PR DESCRIPTION
Without this patch, the bin/upgrade script fails with this traceback:
```
  File "/home/ale/.buildout/eggs/cp311/ftw.upgrade-3.3.1-py3.11-linux-x86_64.egg/ftw/upgrade/command/list_cmd.py", line 84, in format_proposed_upgrades
    for upgrade in response.json():
                   ^^^^^^^^^^^^^^^
  File "/home/ale/.buildout/eggs/cp311/requests-2.31.0-py3.11.egg/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```